### PR TITLE
fix: fix nvm loading node path twice

### DIFF
--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -15,9 +15,6 @@ fi
 # Load aliases
 [[ -f $DOTDIR/aliases ]] && source $DOTDIR/aliases
 
-# Load nvm
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
 # This is to avoid the reattach to user namespace bug
 # export DISABLE_AUTO_TITLE=true
 


### PR DESCRIPTION
The node plugin for prezto already puts nvm modules in the path